### PR TITLE
Rudimentary support for LEO

### DIFF
--- a/README.org
+++ b/README.org
@@ -72,7 +72,7 @@
 
 ** Backends
 
-   Two thesaurus backends are implemented right now in various states of
+   Three thesaurus backends are implemented right now in various states of
    completion.
 
    *Openthesaurus* is a open German thesaurus and is supported quite well, but
@@ -84,6 +84,11 @@
    simple lists of synonyms. Not many of these features are supported by
    synosaurus, yet. Wordnet's backend function is called
    ~synosaurus-backend-wordnet~.
+
+   *LEO* is an online dictionary supporting a small number of language pairs
+   involving English or German. Only German -> English translations are
+   supported at the moment. Its backend function is called
+   ~synosaurus-backend-leo~.
 
 ** Dependencies
 

--- a/synosaurus-leo.el
+++ b/synosaurus-leo.el
@@ -1,0 +1,57 @@
+;;; synosaurus-el.el --- dict.leo.org backend for synosaurus  -*- lexical-binding: t -*-
+
+;; Copyright (C) 2021  hrdl
+;; based on works
+;; Copyright (C) 2019 Hans-Peter Deifel <hpd@hpdeifel.de>
+
+;; Author: hrdl <emacs@hrdl.eu>
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; German -> English dictionary via dict.leo.org
+
+;;; Code:
+
+(require 'synosaurus)
+(require 'url)
+
+(require 'cl-lib)
+(require 'xml)
+(require 'dom)
+
+(defvar synosaurus-leo--url
+  "https://dict.leo.org/dictQuery/m-vocab/ende/query.xml?search=%s&side=right")
+
+;;;###autoload
+(defun synosaurus-backend-leo (word)
+  "TODO"
+  (let ((buf (url-retrieve-synchronously (format synosaurus-leo--url
+                                                 (url-hexify-string word)))))
+    (if (not buf)
+        (error "Could not retrieve leo data")
+      (with-current-buffer buf
+        (goto-char (point-min))
+	(let* ((tree (xml--parse-buffer t nil))
+	       (nodes_en (dom-search (cdr tree)
+				     (lambda (node) (and
+						     (string= (dom-tag node) "side")
+						     (string= (dom-attr node 'lang) "en"))))))
+	  (kill-buffer)
+	  (mapcar (lambda (node) (substring-no-properties (dom-text (dom-child-by-tag (dom-child-by-tag node 'words) 'word)))) nodes_en))))))
+
+
+(provide 'synosaurus-leo)
+;;; synosaurus-leo.el ends here

--- a/synosaurus.el
+++ b/synosaurus.el
@@ -65,10 +65,12 @@ Valid values are:
 Built-in backends are
 
   - synosaurus-backend-wordnet        An english offline thesaurus
-  - synosaurus-backend-openthesaurus  A german online thesaurus"
+  - synosaurus-backend-openthesaurus  A german online thesaurus
+  - synosaurus-backend-leo            A German-English online dictionary"
   :group 'synosaurus
   :type  '(choice (const :tag "Wordnet" synosaurus-backend-wordnet)
                   (const :tag "OpenThesaurus" synosaurus-backend-openthesaurus)
+		  (const :tag "Leo" synosaurus-backend-leo)
                   (function :tag "Other")))
 (make-variable-buffer-local 'synosaurus-backend)
 


### PR DESCRIPTION
Supports German -> English translations only. Extension to other language
pairs is straightforward by modifying the URL, ideally in a configurable
fashion. This can be extended to direction of the lookup (e.g. English ->
German, English <-> German) via the `side` parameter.

Relies on dom.el, which started shiping with emacs 25.1.